### PR TITLE
Fix compilation error - FMBase changed from application to library

### DIFF
--- a/FMSim/FMBase/FMBase.csproj
+++ b/FMSim/FMBase/FMBase.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
FMBase project doesn't have an entrypoint and required the change from app to library status